### PR TITLE
update readme example to create CHRIS/ under data/ if it doesn't exist.

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,9 @@ function datasource(asset::String; save_downloads::Bool=true)::TS
     else
         X = quandl(asset)
         if save_downloads
+            if !isdir(dirname(savedata_path))
+                mkdir(dirname(savedata_path))
+            end
             Temporal.tswrite(X, savedata_path)
         end
         return X
@@ -104,4 +107,3 @@ surface(x, y, z)
 * Define a more diverse set of order types
     - Limit orders
     * Stop orders
-


### PR DESCRIPTION
Running the original example code as is, for the first time, Temporal.tswrite(X, savedata_path) fails to create the downloaded csv file, because it tries to write to data/CHRIS/CME_CL1.csv when CHRIS/ subdirectoy does not (yet) exist. (Quandl id "CHRIS/CME_CL1 having "/" being the cause here.)  This hack, sort of, fixes the above error. Alternatively, escaping '/'(slash) to something like '_"(underscore) maybe a better solution...  Thanks Takehiro